### PR TITLE
Update pulseeffects to v3.2.0

### DIFF
--- a/com.github.wwmm.pulseeffects.json
+++ b/com.github.wwmm.pulseeffects.json
@@ -36,7 +36,7 @@
       "sources": [{
         "type": "git",
         "url": "https://github.com/wwmm/pulseeffects.git",
-        "branch": "v3.2.0",
+        "tag": "v3.2.0",
         "commit": "14f6e8ac46773311a114d7edc178833d41ea6a99"
       }],
       "post-install": [
@@ -345,7 +345,7 @@
                 {
                   "type": "git",
                   "url": "https://github.com/swh/ladspa.git",
-                  "branch": "v0.4.17",
+                  "tag": "v0.4.17",
                   "commit": "8b50f3434b8b30dff16020d17608ced9ee04477b"
                 },
                 {
@@ -402,7 +402,7 @@
                   "sources": [{
                     "type": "git",
                     "url": "https://github.com/c4dm/vamp-plugin-sdk",
-                    "branch": "vamp-plugin-sdk-v2.7.1",
+                    "tag": "vamp-plugin-sdk-v2.7.1",
                     "commit": "10be490c9902d874e9d772d94bf91448303d9b06"
                   }],
                   "post-install": [
@@ -530,7 +530,7 @@
                   "sources": [{
                     "type": "git",
                     "url": "https://github.com/FluidSynth/fluidsynth.git",
-                    "branch": "v1.1.8",
+                    "tag": "v1.1.8",
                     "commit": "12e7afe3a806a6b397f28e0ca4bc6bab9ebe7047"
                   }],
                   "post-install": [
@@ -549,7 +549,7 @@
                 {
                   "type": "git",
                   "url": "https://github.com/zamaudio/zam-plugins.git",
-                  "branch": "3.9",
+                  "tag": "3.9",
                   "commit": "4976cf204074c1dfaf344821e83e8d896b35107d"
                 },
                 {

--- a/com.github.wwmm.pulseeffects.json
+++ b/com.github.wwmm.pulseeffects.json
@@ -36,8 +36,8 @@
       "sources": [{
         "type": "git",
         "url": "https://github.com/wwmm/pulseeffects.git",
-        "branch": "v3.1.7",
-        "commit": "8fd1ee2b7e56d404d4bbc14cf4dad3dea3f455a1"
+        "branch": "v3.2.0",
+        "commit": "14f6e8ac46773311a114d7edc178833d41ea6a99"
       }],
       "post-install": [
         "install -Dm644 ../LICENSE.md /app/share/licenses/com.github.wwmm.pulseeffects/LICENSE"
@@ -195,7 +195,6 @@
             "--disable-assrender",
             "--disable-voamrwbenc",
             "--disable-voaacenc",
-            "--disable-bs2b",
             "--disable-bz2",
             "--disable-chromaprint",
             "--disable-curl",
@@ -581,6 +580,19 @@
               "post-install": [
                 "install -Dm644 LICENSE.txt /app/share/licenses/lsp-plugins/LICENSE.txt"
               ]
+            },
+            /* Other Plugin Types */
+            {
+              "name": "bs2b",
+              "sources": [{
+                "type": "archive",
+                "url": "https://downloads.sourceforge.net/sourceforge/bs2b/libbs2b-3.1.0.tar.gz",
+                "sha256": "6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528"
+              }],
+              "post-install": [
+                "install -Dm644 COPYING /app/share/licenses/bs2b/COPYING"
+              ],
+              "cleanup": [ "/bin" ]
             }
           ]
         }

--- a/com.github.wwmm.pulseeffects.json
+++ b/com.github.wwmm.pulseeffects.json
@@ -329,8 +329,8 @@
               },
               "sources": [{
                 "type": "archive",
-                "url": "http://www.fftw.org/fftw-3.3.6-pl2.tar.gz",
-                "sha256": "a5de35c5c824a78a058ca54278c706cdf3d4abba1c56b63531c2cb05f5d57da2"
+                "url": "http://www.fftw.org/fftw-3.3.7.tar.gz",
+                "md5": "0d5915d7d39b3253c1cc05030d79ac47"
               }],
               "post-install": [
                 "install -Dm644 COPYING /app/share/licenses/fftw/COPYING",
@@ -392,8 +392,8 @@
                   },
                   "sources": [{
                     "type": "archive",
-                    "url": "http://www.fftw.org/fftw-3.3.6-pl2.tar.gz",
-                    "sha256": "a5de35c5c824a78a058ca54278c706cdf3d4abba1c56b63531c2cb05f5d57da2"
+                    "url": "http://www.fftw.org/fftw-3.3.7.tar.gz",
+                    "md5": "0d5915d7d39b3253c1cc05030d79ac47"
                   }],
                   "cleanup": [ "/bin", "/share/man" ]
                 },

--- a/com.github.wwmm.pulseeffects.json
+++ b/com.github.wwmm.pulseeffects.json
@@ -63,9 +63,10 @@
             "-DCBLAS=ON"
           ],
           "sources": [{
-            "type": "archive",
-            "url": "http://www.netlib.org/lapack/lapack-3.7.1.tgz",
-            "sha256": "f6c53fd9f56932f3ddb3d5e24c1c07e4cd9b3b08e7f89de9c867125eecc9a1c8"
+            "type": "git",
+            "url": "https://github.com/Reference-LAPACK/lapack-release",
+            "branch": "lapack-3.8.0",
+            "commit": "ba3779a6813d84d329b73aac86afc4e041170609"
           }],
           "post-install": [
             "install -Dm644 ../LICENSE /app/share/licenses/lapack/LICENSE"

--- a/com.github.wwmm.pulseeffects.json
+++ b/com.github.wwmm.pulseeffects.json
@@ -361,8 +361,8 @@
               "name": "rubberband",
               "sources": [{
                 "type": "archive",
-                "url": "http://code.breakfastquay.com/attachments/download/34/rubberband-1.8.1.tar.bz2",
-                "sha256": "ff0c63b0b5ce41f937a8a3bc560f27918c5fe0b90c6bc1cb70829b86ada82b75"
+                "url": "https://bitbucket.org/breakfastquay/rubberband/get/v1.8.1.tar.gz",
+                "sha256": "9bea85fc2e4d8c3044e3b87c6ecff4282a61a888bafe0ce07cee11fc0ea68f16"
               }],
               "post-install": [
                 "install -Dm644 COPYING /app/share/licenses/rubberband/COPYING"
@@ -399,9 +399,10 @@
                 {
                   "name": "vamp-plugin-sdk",
                   "sources": [{
-                    "type": "archive",
-                    "url": "https://code.soundsoftware.ac.uk/attachments/download/2206/vamp-plugin-sdk-2.7.1.tar.gz",
-                    "sha256": "c6fef3ff79d2bf9575ce4ce4f200cbf219cbe0a21cfbad5750e86ff8ae53cb0b"
+                    "type": "git",
+                    "url": "https://github.com/c4dm/vamp-plugin-sdk",
+                    "branch": "vamp-plugin-sdk-v2.7.1",
+                    "commit": "10be490c9902d874e9d772d94bf91448303d9b06"
                   }],
                   "post-install": [
                     "install -Dm644 COPYING /app/share/licenses/vamp-plugin-sdk/COPYING"
@@ -563,14 +564,13 @@
             },
             {
               "name": "lsp-plugins",
-              "subdir": "lsp-plugins",
               "no-autogen": true,
-              "skip-arches": [ "i386" ],
+              "only-arches": [ "x86_64" ],
               "sources": [
                 {
                   "type": "archive",
-                  "url": "https://sourceforge.net/code-snapshots/svn/l/ls/lsp-plugins/svn/lsp-plugins-svn-13-trunk.zip",
-                  "sha256": "f92fe19282b5cd27d325dc0f50d3f250a9d8fc62cf8e5c6b0cc1d7f585b2bfd0"
+                  "url": "https://sourceforge.net/projects/lsp-plugins/files/scr/scr-1.0.4/lsp-plugins-src-scr-1.0.4.tar.gz",
+                  "sha256": "29df4a42f029cde2036ce499a24b00854069a5f2da78940809d64094809e8bf8"
                 },
                 {
                   "type": "patch",

--- a/lsp-plugins.patch
+++ b/lsp-plugins.patch
@@ -1,6 +1,6 @@
-diff -urN a/lsp-plugins/Makefile b/lsp-plugins/Makefile
---- a/lsp-plugins/Makefile	2018-01-01 21:32:16.000000000 +0100
-+++ b/lsp-plugins/Makefile	2018-01-25 18:11:17.036172544 +0100
+diff -urN a/Makefile b/Makefile
+--- a/Makefile	2018-01-26 21:44:10.471163537 +0100
++++ b/Makefile	2018-02-07 17:37:15.452336504 +0100
 @@ -1,6 +1,6 @@
 -BIN_PATH                = /usr/local/bin
 -LIB_PATH                = /usr/local/lib
@@ -42,9 +42,9 @@ diff -urN a/lsp-plugins/Makefile b/lsp-plugins/Makefile
  	@$(UTL_GENTTL) $(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2
  	
  install_vst: all
-diff -urN a/lsp-plugins/src/container/Makefile b/lsp-plugins/src/container/Makefile
---- a/lsp-plugins/src/container/Makefile	2017-05-24 23:41:11.000000000 +0200
-+++ b/lsp-plugins/src/container/Makefile	2018-01-25 18:09:37.629903211 +0100
+diff -urN a/src/container/Makefile b/src/container/Makefile
+--- a/src/container/Makefile	2018-01-26 21:44:10.457163653 +0100
++++ b/src/container/Makefile	2018-02-07 17:38:53.470646837 +0100
 @@ -4,7 +4,7 @@
  OBJ_HELPERS             = $(OBJDIR)/CairoCanvas.o
  
@@ -54,9 +54,9 @@ diff -urN a/lsp-plugins/src/container/Makefile b/lsp-plugins/src/container/Makef
  ifdef VST_SDK
  MODULES                += $(LIB_VST)
  endif
-diff -urN a/lsp-plugins/src/Makefile b/lsp-plugins/src/Makefile
---- a/lsp-plugins/src/Makefile	2017-05-24 23:41:11.000000000 +0200
-+++ b/lsp-plugins/src/Makefile	2018-01-25 18:06:47.626306154 +0100
+diff -urN a/src/Makefile b/src/Makefile
+--- a/src/Makefile	2018-01-26 21:44:10.455163670 +0100
++++ b/src/Makefile	2018-02-07 17:40:15.563556637 +0100
 @@ -1,5 +1,5 @@
 -SUBDIRS                 = core metadata plugins ui utils container doc
 -MODULES                 = $(SUBDIRS) jack_stub


### PR DESCRIPTION
PulseEffects now require bs2b library as a dependency.