### PR TITLE
Update to version 4.8.3 and add RNNoise module

### DIFF
--- a/com.github.wwmm.pulseeffects.yml
+++ b/com.github.wwmm.pulseeffects.yml
@@ -45,8 +45,8 @@ modules:
     sources:
       - type: git
         url: 'https://github.com/wwmm/pulseeffects.git'
-        tag: v4.8.2
-        commit: 51ec2051c093c8bdd5992cd083bb87ebf942bc8f
+        tag: v4.8.3
+        commit: f5f83831f3713a5268356286f8044e1db2950834
     post-install:
       - install -Dm644 -t $FLATPAK_DEST/share/licenses/com.github.wwmm.pulseeffects ../LICENSE.md
       - mkdir -pm755 /app/extensions/Plugins
@@ -317,3 +317,12 @@ modules:
             cleanup:
               - /lib/lv2
               - /lib/vst
+
+      - name: rnnoise
+        buildsystem: autotools
+        sources:
+          - type: git
+            url: 'https://github.com/xiph/rnnoise.git'
+            commit: 90ec41ef659fd82cfec2103e9bb7fc235e9ea66c
+        cleanup:
+          - /share/doc/rnnoise


### PR DESCRIPTION
> *Note: It's not possible to update to 4.8.4 right now as there is no such git tag yet. I created an issue to request adding this tag:* https://github.com/wwmm/pulseeffects/issues/868

this commit updates Pulseeffects to version 4.8.3

This also adds the https://github.com/xiph/rnnoise module to get the new Noise Reduction feature, which is awesome! Works even better than WebRTC.