### PR TITLE
pulseeffects: Update to version 4.8.4 and add RNNoise module support

### DIFF
--- a/com.github.wwmm.pulseeffects.yml
+++ b/com.github.wwmm.pulseeffects.yml
@@ -45,8 +45,8 @@ modules:
     sources:
       - type: git
         url: 'https://github.com/wwmm/pulseeffects.git'
-        tag: v4.8.2
-        commit: 51ec2051c093c8bdd5992cd083bb87ebf942bc8f
+        tag: v4.8.4
+        commit: 4e7532f72ea59b9001d2d1ae544f03fca6c73a34
     post-install:
       - install -Dm644 -t $FLATPAK_DEST/share/licenses/com.github.wwmm.pulseeffects ../LICENSE.md
       - mkdir -pm755 /app/extensions/Plugins

--- a/com.github.wwmm.pulseeffects.yml
+++ b/com.github.wwmm.pulseeffects.yml
@@ -317,3 +317,12 @@ modules:
             cleanup:
               - /lib/lv2
               - /lib/vst
+
+      - name: rnnoise
+        buildsystem: autotools
+        sources:
+          - type: git
+            url: 'https://github.com/xiph/rnnoise.git'
+            commit: 90ec41ef659fd82cfec2103e9bb7fc235e9ea66c
+        cleanup:
+          - /share/doc/rnnoise


### PR DESCRIPTION
this PR updates Pulseeffects to version 4.8.4

This also adds the xiph/rnnoise module to get the new Noise Reduction feature, which is awesome! Works even better than WebRTC.

~~*Draft until I got a response from @wwmm regarding if there should be more dependency updates in issue https://github.com/wwmm/pulseeffects/issues/868#issuecomment-756439655*~~