### PR TITLE
Update and change download source for boost

### DIFF
--- a/com.github.wwmm.pulseeffects.yml
+++ b/com.github.wwmm.pulseeffects.yml
@@ -60,8 +60,8 @@ modules:
             toolset=gcc variant=release link=shared threading=multi install
         sources:
           - type: archive
-            url: 'https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.gz'
-            sha256: aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a
+            url: 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz'
+            sha256: 7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca
         post-install:
           - install -Dm644 -t $FLATPAK_DEST/share/licenses/boost LICENSE_1_0.txt
         cleanup:


### PR DESCRIPTION
Updates boost module to 1.76.0 from 1.75.0. This is for the master branch, [that should forever stay on 4.0.x (pulseaudio only)](https://github.com/flathub/com.github.wwmm.pulseeffects/issues/44#issuecomment-832727759). It can be considered a simple maintenance change. Perhaps flathubbot could be made to automatically make PR's for boost.org's files to automate these changes in the future. I'm not sure how exactly that's done so for now this is just a manual change.

Updates download url to no longer use the shut down bintray, news sourced from [boost.org](https://boost.org). See this [blog post](https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html) announcing the change.

Curiously the date on the blog post is in the future (published September 2nd 2021), but the reasoning behind the post does seem to be correct, [bintray.com](https://bintray.com) is no longer operational as of May 1st 2021 according to bintray itself. Update: It appears boost.org disabled their time machine, and [their blog post](https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html) now reads April 29th 2021 which seems more reasonable.

There is no open issue for this specific fix.

This change was also tested as part of https://github.com/flathub/com.github.wwmm.pulseeffects/pull/51 so if that PR is safe to approve this one should probably be ok as well.