### PR TITLE
update deprecated boost url

### DIFF
--- a/com.github.wwmm.pulseeffects.json
+++ b/com.github.wwmm.pulseeffects.json
@@ -62,12 +62,12 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.gz",
+                            "url": "https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz",
                             "sha256": "a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 6845,
-                                "url-template": "https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_${patch}.tar.gz"
+                                "url-template": "https://archives.boost.io/release/$version/source/boost_${major}_${minor}_${patch}.tar.gz"
                             }
                         }
                     ],


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
